### PR TITLE
Add default components to /ask

### DIFF
--- a/asker/commands.go
+++ b/asker/commands.go
@@ -180,6 +180,7 @@ func (a *Asker) PostAskResult(originalAsk *SlashCommand, request *InteractiveReq
 		Summary:     request.Submission["summary"],
 		Description: request.Submission["description"],
 		ProjectKey:  originalAsk.Config.Project,
+		Components:  originalAsk.Config.Components,
 	}
 	log.Printf("Creating a JIRA ticket in %s by %s\n", ticket.ProjectKey, ticket.Username)
 	issue, err := a.Jira.CreateIssue(&ticket)

--- a/asker/commands.go
+++ b/asker/commands.go
@@ -30,6 +30,7 @@ type TicketRequest struct {
 	Summary     string
 	Description string
 	Priority    string
+	Components  []string
 }
 
 type InteractiveRequest struct {

--- a/asker/jira.go
+++ b/asker/jira.go
@@ -30,7 +30,13 @@ func (ask *Asker) NewJira(endpoint string, username string, password string, pub
 func (j *JiraClient) CreateIssue(issueRequest *TicketRequest) (*jira.Issue, error) {
 	project, _, err := j.client.Project.Get(issueRequest.ProjectKey)
 	if err != nil {
-		log.Printf("Unable to fetch JIRA Project: %s\n", err)
+		log.Printf("Unable to fetch JIRA project `%s`: %s\n", issueRequest.ProjectKey, err)
+		return nil, err
+	}
+
+	components, err := j.getComponentsForRequest(issueRequest)
+	if err != nil {
+		log.Printf("Unable to fetch JIRA components for `%s`: %s\n", issueRequest.ProjectKey, err)
 		return nil, err
 	}
 
@@ -41,6 +47,7 @@ func (j *JiraClient) CreateIssue(issueRequest *TicketRequest) (*jira.Issue, erro
 			Project:     jira.Project{Key: issueRequest.ProjectKey},
 			Summary:     issueRequest.Summary,
 			Description: issueRequest.Description,
+			Components:  components,
 		},
 	}
 	issue, resp, err := j.client.Issue.Create(i)
@@ -51,6 +58,10 @@ func (j *JiraClient) CreateIssue(issueRequest *TicketRequest) (*jira.Issue, erro
 	}
 
 	return issue, nil
+}
+
+func (j *JiraClient) getComponentsForRequest(issueRequest *TicketRequest) ([]*jira.Component, error) {
+	return nil, nil
 }
 
 func (j *JiraClient) GetTicketURL(key string) string {

--- a/asker/jira.go
+++ b/asker/jira.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"strings"
 
 	jira "github.com/andygrunwald/go-jira"
 )
@@ -34,7 +35,7 @@ func (j *JiraClient) CreateIssue(issueRequest *TicketRequest) (*jira.Issue, erro
 		return nil, err
 	}
 
-	components, err := j.getComponentsForRequest(issueRequest)
+	components, err := j.getComponentsForRequest(project, issueRequest)
 	if err != nil {
 		log.Printf("Unable to fetch JIRA components for `%s`: %s\n", issueRequest.ProjectKey, err)
 		return nil, err
@@ -60,8 +61,17 @@ func (j *JiraClient) CreateIssue(issueRequest *TicketRequest) (*jira.Issue, erro
 	return issue, nil
 }
 
-func (j *JiraClient) getComponentsForRequest(issueRequest *TicketRequest) ([]*jira.Component, error) {
-	return nil, nil
+func (j *JiraClient) getComponentsForRequest(project *jira.Project, issueRequest *TicketRequest) ([]*jira.Component, error) {
+	var components []*jira.Component
+
+	for _, compName := range issueRequest.Components {
+		for _, projectComponent := range project.Components {
+			if strings.ToLower(projectComponent.Name) == strings.ToLower(compName) {
+				components = append(components, &jira.Component{ID: projectComponent.ID, Name: projectComponent.Name})
+			}
+		}
+	}
+	return components, nil
 }
 
 func (j *JiraClient) GetTicketURL(key string) string {

--- a/asker/storage.go
+++ b/asker/storage.go
@@ -15,6 +15,7 @@ type ChannelConfig struct {
 	ChannelID      string
 	ChannelName    string
 	Project        string
+	Components     []string
 	AssignEndpoint string
 }
 
@@ -31,11 +32,20 @@ func (storage *Storage) CloseStorage() {
 }
 
 func (storage *Storage) SetChannelProject(channelID string, project string) error {
-	chanConfig := &ChannelConfig{ChannelID: channelID, Project: project}
+	channelConfig := &ChannelConfig{ChannelID: channelID, Project: project}
 	c := storage.cxn.DB(storage.database).C(storage.collection)
 
 	// TODO: Validate that project is even legit by talking to the JIRA API
-	_, err := c.UpsertId(chanConfig.ChannelID, chanConfig)
+	_, err := c.UpsertId(channelConfig.ChannelID, channelConfig)
+
+	return err
+}
+
+func (storage *Storage) SetChannelConfig(channelConfig *ChannelConfig) error {
+	c := storage.cxn.DB(storage.database).C(storage.collection)
+
+	// TODO: Validate that project is even legit by talking to the JIRA API
+	_, err := c.UpsertId(channelConfig.ChannelID, channelConfig)
 
 	return err
 }


### PR DESCRIPTION
This adds a `/ask config components Component1 Component2` command. It will not verify that the components are accurate in the first cut, since the storage piece doesn't talk to the JIRA piece yet.

Remaining items:
* [ ] Case insensitive match components from JIRA
* [ ] Actually add the components to the JIRA ticket
* [ ] Validation on the `/ask config` steps
* [ ] Maybe rethink `/ask link <PKEY>` and move to `/ask config project PKEY`, thoughts?

cc @gphat 